### PR TITLE
Use the new .npmrc format

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -12,8 +12,7 @@ module DPL
 
       def setup_auth
         File.open(File.expand_path(NPMRC_FILE), 'w') do |f|
-          f.puts("_auth = ${NPM_API_KEY}")
-          f.puts("email = #{option(:email)}")
+          f.puts("//registry.npmjs.org/:_authToken=${NPM_API_KEY}")
         end
       end
 


### PR DESCRIPTION
For a more detailed example see [this article](http://blog.getpiggybank.com/npm-private-modules-with-heroku/). I presume that this change is the only thing that's required, but I am unfamiliar with your infrastructure. (e.g. I don't know where `NPM_API_KEY` comes from.) 

I do know that npm publishing is currently failing using your [instructions](http://docs.travis-ci.com/user/deployment/npm/). See, for example, this [job](https://travis-ci.org/michaelleeallen/mocha-junit-reporter/jobs/67443955)
